### PR TITLE
[fix] Fix glassfish download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ mvn clean install
 a) Download GlassFish 5.1.0:
 
 ```bash
-$ wget https://www.eclipse.org/downloads/download.php?file=/glassfish/glassfish-5.1.0.zip
+$ wget 'https://www.eclipse.org/downloads/download.php?file=/glassfish/glassfish-5.1.0.zip&r=1' -O glassfish-5.1.0.zip
 $ unzip glassfish-5.1.0.zip
 $ cd glassfish5
 $ echo "AS_JAVA=<path-to-JDK8>" >> ./glassfish/config/asenv.conf


### PR DESCRIPTION
This PR provides a fix for the build instructions.
More specifically, it fixes the glassfish download link.