### PR TITLE
Add support for NebulaStream Java UDFs 

### DIFF
--- a/bin/runCompilation.sh
+++ b/bin/runCompilation.sh
@@ -14,6 +14,15 @@ parameter_size_json_file=$5
 generated_kernel_file=$6
 method_name=$7
 
-## Compile input class file for virtual device 
+## Compile input class file for virtual device
 $tornado_command -cp :$class_path --jvm="-Dtornado.input.classfile.dir=$class_file -Dtornado.device.desc=$device_json_file -Dtornado.parameter.size.dir=$parameter_size_json_file -Dtornado.virtual.device=True -Dtornado.cim.mode=True -Dtornado.print.kernel=True -Dtornado.print.kernel.dir=$generated_kernel_file" uk.ac.manchester.tornado.drivers.opencl.service.frontend.TestFrontEnd --params "$method_name"
+
+exit_code=$?
+
+if [ $exit_code -e 0 ]
+then
+        exit 0
+else
+        exit $exit_code
+fi
 

--- a/examples/inputFiles/customMap.java
+++ b/examples/inputFiles/customMap.java
@@ -1,13 +1,19 @@
-public static Float2 map(Float2 value) {
-        float radius = TornadoMath.sqrt(value.getX() * value.getX() + value.getY() * value.getY());
-        float angle = TornadoMath.atan2(value.getX(), value.getY());
-        Float2 output = new Float2(angle, radius);
+static class CartesianCoordinate {
+    double x;
+    double y;
+}
 
-        return output;
-    }
+// This is he output type of the UDF.
+// The schema of the output stream is derived from the names of the fields
+// `angle` and `radius`.
+static class PolarCoordinate {
+    double angle;
+    double radius;
+}
 
-    public static void customMap(VectorFloat2 in1, VectorFloat2 out) {
-        for (@Parallel int i = 0; i < in1.getLength(); i++) {
-            out.set(i, map(in1.get(i)));
-        }
-    }
+public PolarCoordinate map(final CartesianCoordinate value) {
+    PolarCoordinate output =  new PolarCoordinate();
+    output.radius = Math.sqrt(value.x * value.x + value.y * value.y);
+    output.angle = Math.atan2(value.x, value.y);
+    return output;
+}

--- a/examples/inputFiles/customMapFloat.java
+++ b/examples/inputFiles/customMapFloat.java
@@ -1,0 +1,19 @@
+static class CartesianCoordinate {
+    float x;
+    float y;
+}
+
+// This is he output type of the UDF.
+// The schema of the output stream is derived from the names of the fields
+// `angle` and `radius`.
+static class PolarCoordinate {
+    float angle;
+    float radius;
+}
+
+public PolarCoordinate map(final CartesianCoordinate inputmap) {
+    PolarCoordinate output =  new PolarCoordinate();
+    output.radius = Math.sqrt(inputmap.x * inputmap.x + inputmap.y * inputmap.y);
+    output.angle = Math.atan2(inputmap.x, inputmap.y);
+    return output;
+}

--- a/examples/inputFiles/deviceInfoCustomMap.json
+++ b/examples/inputFiles/deviceInfoCustomMap.json
@@ -1,16 +1,20 @@
 {
   "fileInfo": {
-    "functionName": "customMap",
+    "functionName": "map",
     "programmingLanguage": "Java"
   },
   "parameterSizes": {
-    "in": 1024,
-    "out": 1024
+    "value": 1024,
+    "output": 1024
   },
   "deviceInfo": {
     "deviceName": "Nvidia GPU",
     "doubleFPSupport": true,
-    "maxWorkItemSizes": [16, 1, 1],
+    "maxWorkItemSizes": [
+      16,
+      1,
+      1
+    ],
     "deviceAddressBits": 64,
     "deviceType": "CL_DEVICE_TYPE_GPU",
     "deviceExtensions": "cl_khr_int64_base_atomics",

--- a/examples/inputFiles/vectorAdd.java
+++ b/examples/inputFiles/vectorAdd.java
@@ -1,5 +1,5 @@
 public static void vectorAdd(int[] a, int[] b, int[] c) {
-    for (@Parallel int i = 0; i < c.length; i++) {
+    for ( int i = 0; i < c.length; i++) {
         c[i] = a[i] + b[i];
     }
 }

--- a/examples/inputFiles/vectorAdd2.java
+++ b/examples/inputFiles/vectorAdd2.java
@@ -1,5 +1,5 @@
 public static void vectorAdd2(int[] a, int[] b, int[] c) {
-    for (@Parallel int i = 0; i < c.length; i++) {
+    for (int i = 0; i < c.length; i++) {
         c[i] = a[i] + b[i];
     }
 }

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/api/ElegantAccelerationService.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/api/ElegantAccelerationService.java
@@ -110,10 +110,10 @@ public class ElegantAccelerationService {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/submit")
-    public Response uploadFile(@FormDataParam("codeFile") InputStream codeFileInputStream,
-                               @FormDataParam("codeFile") FormDataContentDisposition codeFileMetaData,
-                               @FormDataParam("jsonFile") InputStream jsonFileInputStream,
-                               @FormDataParam("jsonFile") FormDataContentDisposition jsonFileMetaData) throws IOException, InterruptedException {
+    public Response uploadFile(@FormDataParam("codeFile") InputStream codeFileInputStream, //
+            @FormDataParam("codeFile") FormDataContentDisposition codeFileMetaData, //
+            @FormDataParam("jsonFile") InputStream jsonFileInputStream, //
+            @FormDataParam("jsonFile") FormDataContentDisposition jsonFileMetaData) throws IOException, InterruptedException {
         TransactionMetaData transactionMetaData = null;
         String msg = "Accepted request. Files uploaded.";
 
@@ -137,7 +137,7 @@ public class ElegantAccelerationService {
             ElegantRequestHandler.addOrUpdateUploadedDeviceJsonFileName(transactionMetaData.getCompilationRequest(), transactionMetaData.getJsonFileName());
             ElegantRequestHandler.addOrUpdateUploadedFileInfoFileName(transactionMetaData.getCompilationRequest(), transactionMetaData.getFileInfoName());
             ElegantRequestHandler.addOrUpdateUploadedParameterSizeJsonFileName(transactionMetaData.getCompilationRequest(), transactionMetaData.getParameterSizeFileName());
-            ElegantRequestHandler.compile(tornadoVM, transactionMetaData);
+            msg = ElegantRequestHandler.compile(tornadoVM, transactionMetaData);
         }
 
         return transactionMetaData.response;
@@ -148,11 +148,11 @@ public class ElegantAccelerationService {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/{requestId}/resubmit")
-    public Response updateAndCompile(@PathParam("requestId") long requestId,
-                                     @FormDataParam("codeFile") InputStream codeFileInputStream,
-                                     @FormDataParam("codeFile") FormDataContentDisposition codeFileMetaData,
-                                     @FormDataParam("jsonFile") InputStream jsonFileInputStream,
-                                     @FormDataParam("jsonFile") FormDataContentDisposition jsonFileMetaData) throws IOException, InterruptedException {
+    public Response updateAndCompile(@PathParam("requestId") long requestId, //
+            @FormDataParam("codeFile") InputStream codeFileInputStream, //
+            @FormDataParam("codeFile") FormDataContentDisposition codeFileMetaData, //
+            @FormDataParam("jsonFile") InputStream jsonFileInputStream, //
+            @FormDataParam("jsonFile") FormDataContentDisposition jsonFileMetaData) throws IOException, InterruptedException {
         TransactionMetaData transactionMetaData = null;
         String msg = "Accepted request. Files uploaded.";
 
@@ -182,7 +182,7 @@ public class ElegantAccelerationService {
             ElegantRequestHandler.addOrUpdateUploadedFunctionFileName(transactionMetaData.getCompilationRequest(), transactionMetaData.getFunctionFileName());
             ElegantRequestHandler.addOrUpdateUploadedDeviceJsonFileName(transactionMetaData.getCompilationRequest(), transactionMetaData.getJsonFileName());
             ElegantRequestHandler.addOrUpdateUploadedParameterSizeJsonFileName(transactionMetaData.getCompilationRequest(), transactionMetaData.getParameterSizeFileName());
-            ElegantRequestHandler.compile(tornadoVM, transactionMetaData);
+            msg = ElegantRequestHandler.compile(tornadoVM, transactionMetaData);
         }
 
         return transactionMetaData.response;

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/controller/CompilationRequest.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/controller/CompilationRequest.java
@@ -35,10 +35,6 @@ public class CompilationRequest {
 
     private State state;
 
-    private String sourceCode; // TODO: Save the source code as a String
-
-    private String acceleratedCode; // TODO: Save the acceleratedCode code as a String
-
     public CompilationRequest(FileInfo fileInfo, DeviceInfo deviceInfo, ParameterInfo parameterInfo) {
         this.fileInfo = fileInfo;
         this.deviceInfo = deviceInfo;

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/controller/ElegantRequestHandler.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/controller/ElegantRequestHandler.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-//TODO Make methods static
 public class ElegantRequestHandler {
 
     private static String fileGeneratedPath;

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/controller/ElegantRequestHandler.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/controller/ElegantRequestHandler.java
@@ -141,8 +141,9 @@ public class ElegantRequestHandler {
         mapOfUploadedFileInfoJsonFileNames.remove(id);
     }
 
-    // TODO: Update with invocation to the integrated compilers
-    public static void compile(LinuxTornadoVM tornadoVM, TransactionMetaData transactionMetaData) throws IOException, InterruptedException {
+    public static String compile(LinuxTornadoVM tornadoVM, TransactionMetaData transactionMetaData) throws IOException, InterruptedException {
+        String message = null;
+        Response.Status status = null;
         CompilationRequest compilerRequest = transactionMetaData.getCompilationRequest();
         File idDirectory = new File(fileGeneratedPath + File.separator + compilerRequest.getId());
         if (!idDirectory.exists()) {
@@ -157,17 +158,48 @@ public class ElegantRequestHandler {
         String generatedKernelFileName = mapOfGeneratedKernelNames.get(compilerRequest.getId());
 
         tornadoVM.compileToBytecode(compilerRequest.getId(), methodFileName, kernelName);
+        transactionMetaData.getCompilationRequest().setState(CompilationRequest.State.SUBMITTED);
         tornadoVM.compileBytecodeToOpenCL(compilerRequest.getId(), deviceDescriptionJsonFileName, kernelName, parameterSizeJsonFileName, generatedKernelFileName);
 
         if (tornadoVM.getExitCode() == 0) {
             transactionMetaData.getCompilationRequest().setState(CompilationRequest.State.COMPLETED);
-        } else {
+            message = "The request has been completed.\n" + "New code acceleration request has been registered (#" + transactionMetaData.getCompilationRequest().getId() + ")\n";
+            status = Response.Status.ACCEPTED;
+        } else if (tornadoVM.getBytecodeExitCode() != 0) {
             transactionMetaData.getCompilationRequest().setState(CompilationRequest.State.FAILED);
+            message = "The bytecode compilation command failed with error code(" + tornadoVM.getBytecodeExitCode() + ").\nCheck the server log.\n";
+            status = Response.Status.INTERNAL_SERVER_ERROR;
+        } else if (tornadoVM.getTornadoExitCode() != 0) {
+            transactionMetaData.getCompilationRequest().setState(CompilationRequest.State.UNSUPPORTED);
+            status = Response.Status.INTERNAL_SERVER_ERROR;
+            message = "The TornadoVM compilation command failed with error code(" + tornadoVM.getTornadoExitCode() + ").\n";
+            switch (tornadoVM.getTornadoExitCode()) {
+                case 3:
+                    message += "An error occured in TornadoVM, when reflection was used.\n";
+                    break;
+                case 4:
+                    message += "An error occured in TornadoVM, related to the parameter file.\n";
+                    break;
+                case 5:
+                    message += "An error occured in TornadoVM, in the compiler.\n";
+                    break;
+                case 6:
+                    message += "An error occured in TornadoVM, regarding the virtual device.\n";
+                    break;
+                default:
+                    break;
+            }
+            message += "Check the server log.\n";
+        } else {
+            status = Response.Status.NOT_IMPLEMENTED;
+            message = "Should not reach here.\n";
         }
         transactionMetaData.response = Response//
-                .status(Response.Status.ACCEPTED)//
+                .status(status)//
                 .type(MediaType.TEXT_PLAIN_TYPE)//
-                .entity("New code acceleration request has been registered (#" + transactionMetaData.getCompilationRequest().getId() + ")\n")//
+                .entity(message)//
                 .build();
+
+        return message;
     }
 }

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/controller/ElegantRequestHandler.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/controller/ElegantRequestHandler.java
@@ -156,9 +156,8 @@ public class ElegantRequestHandler {
         String parameterSizeJsonFileName = mapOfUploadedParameterSizeFileNames.get(compilerRequest.getId());
         String generatedKernelFileName = mapOfGeneratedKernelNames.get(compilerRequest.getId());
 
-        //TODO Tornadify the operator
-        tornadoVM.compileToBytecode(compilerRequest.getId(), methodFileName);
-        tornadoVM.compileBytecodeToOpenCL(compilerRequest.getId(), methodFileName, deviceDescriptionJsonFileName, kernelName, parameterSizeJsonFileName, generatedKernelFileName);
+        tornadoVM.compileToBytecode(compilerRequest.getId(), methodFileName, kernelName);
+        tornadoVM.compileBytecodeToOpenCL(compilerRequest.getId(), deviceDescriptionJsonFileName, kernelName, parameterSizeJsonFileName, generatedKernelFileName);
 
         if (tornadoVM.getExitCode() == 0) {
             transactionMetaData.getCompilationRequest().setState(CompilationRequest.State.COMPLETED);

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/ClassGenerator.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/ClassGenerator.java
@@ -33,14 +33,25 @@ public class ClassGenerator {
     private static final String SUFFIX = ".java";
     private static StringBuilder stringBuilder;
 
-    private static void emitPackagePrologue(StringBuilder sb) {
+    private static void emitPackagePrologue(StringBuilder sb, OperatorInfo operatorInfo) {
         sb.append("import uk.ac.manchester.tornado.api.annotations.Parallel;");
         sb.append("\n");
-        sb.append("import uk.ac.manchester.tornado.api.collections.math.TornadoMath;");
-        sb.append("\n");
-        sb.append("import uk.ac.manchester.tornado.api.collections.types.Float2;");
-        sb.append("\n");
-        sb.append("import uk.ac.manchester.tornado.api.collections.types.VectorFloat2;");
+        if (operatorInfo.methodUsesMathPackage) {
+            sb.append("import uk.ac.manchester.tornado.api.collections.math.TornadoMath;");
+            sb.append("\n");
+        }
+
+        String[] operatorNames = OperatorParser.getUniqueOperatorName(operatorInfo);
+        for (int i = 0; i < operatorNames.length; i++) {
+            sb.append("import uk.ac.manchester.tornado.api.collections.types.");
+            sb.append(operatorNames[i]);
+            sb.append(";");
+            sb.append("\n");
+            sb.append("import uk.ac.manchester.tornado.api.collections.types.Vector");
+            sb.append(operatorNames[i]);
+            sb.append(";");
+            sb.append("\n");
+        }
         sb.append("\n");
     }
 
@@ -135,9 +146,9 @@ public class ClassGenerator {
         return className + SUFFIX;
     }
 
-    public static String generateBoilerplateCode(String methodFileName, String functionName) {
+    public static String generateBoilerplateCode(String methodFileName, String functionName, OperatorInfo operatorInfo) {
         stringBuilder = new StringBuilder();
-        emitPackagePrologue(stringBuilder);
+        emitPackagePrologue(stringBuilder, operatorInfo);
         String className = getVirtualClassName(functionName);
         emitClassBegin(stringBuilder, className);
         String udfBody = extractUdfBodyFromFileToString(methodFileName);

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/ClassGenerator.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/ClassGenerator.java
@@ -52,7 +52,7 @@ public class ClassGenerator {
         sb.append("\n");
     }
 
-    private static void emitMethod(StringBuilder sb, String method) {
+    private static void emitUdfBody(StringBuilder sb, String method) {
         sb.append("\n");
         sb.append(method);
     }
@@ -62,7 +62,7 @@ public class ClassGenerator {
         sb.append("\n");
     }
 
-    public static String extractMethodFromFileToString(String path) {
+    public static String extractUdfBodyFromFileToString(String path) {
         StringBuilder contentBuilder = new StringBuilder();
 
         try (Stream<String> stream = Files.lines(Paths.get(path), StandardCharsets.UTF_8)) {
@@ -88,12 +88,14 @@ public class ClassGenerator {
         }
     }
 
+    // TODO Deprecate
     private static String getMethodNameFromSignature(String signatureName) {
         String[] strings = signatureName.split("\\(");
         String[] subStrings = strings[0].split(" ");
         return subStrings[subStrings.length - 1];
     }
 
+    // TODO Deprecate
     public static String getMethodNameFromFileName(String methodFileName) {
         String signatureName = getSignatureOfMethodFile(methodFileName);
         String[] strings = signatureName.split("\\(");
@@ -105,7 +107,7 @@ public class ClassGenerator {
         return line.replaceFirst(" \\{|\\{", ";");
     }
 
-    // TODO Update this to see the all signatures
+    // TODO Deprecate
     private static String getSignatureOfMethodFile(String fileName) {
         FileReader fileReader;
         BufferedReader bufferedReader;
@@ -123,24 +125,23 @@ public class ClassGenerator {
         }
     }
 
-    public static String getVirtualClassName(String methodFileName) {
-        String methodName = getMethodNameFromSignature(getSignatureOfMethodFile(methodFileName));
-        String className = "Test" + methodName.substring(0, 1).toUpperCase() + methodName.substring(1);
+    public static String getVirtualClassName(String functionName) {
+        String className = "Test" + functionName.substring(0, 1).toUpperCase() + functionName.substring(1);
         return className;
     }
 
-    public static String getVirtualClassFileName(String methodFileName) {
-        String className = getVirtualClassName(methodFileName);
+    public static String getVirtualClassFileName(String functionName) {
+        String className = getVirtualClassName(functionName);
         return className + SUFFIX;
     }
 
-    public static String generateBoilerplateCode(String methodFileName) {
+    public static String generateBoilerplateCode(String methodFileName, String functionName) {
         stringBuilder = new StringBuilder();
         emitPackagePrologue(stringBuilder);
-        String className = getVirtualClassName(methodFileName);
+        String className = getVirtualClassName(functionName);
         emitClassBegin(stringBuilder, className);
-        String methodBody = extractMethodFromFileToString(methodFileName);
-        emitMethod(stringBuilder, methodBody);
+        String udfBody = extractUdfBodyFromFileToString(methodFileName);
+        emitUdfBody(stringBuilder, udfBody);
         emitClosingBrace(stringBuilder);
         return stringBuilder.toString();
     }

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/ClassGenerator.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/ClassGenerator.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the ELEGANT Acceleration Service.
+ * URL: https://github.com/elegant-h2020/Elegant-Acceleration-Service.git
+ *
+ * Copyright (c) 2023, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.ac.manchester.elegant.acceleration.service.tools;
 
 import java.io.BufferedReader;
@@ -16,8 +35,11 @@ public class ClassGenerator {
 
     private static void emitPackagePrologue(StringBuilder sb) {
         sb.append("import uk.ac.manchester.tornado.api.annotations.Parallel;");
+        sb.append("\n");
         sb.append("import uk.ac.manchester.tornado.api.collections.math.TornadoMath;");
+        sb.append("\n");
         sb.append("import uk.ac.manchester.tornado.api.collections.types.Float2;");
+        sb.append("\n");
         sb.append("import uk.ac.manchester.tornado.api.collections.types.VectorFloat2;");
         sb.append("\n");
     }

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/ClassGenerator.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/ClassGenerator.java
@@ -419,41 +419,8 @@ public class ClassGenerator {
         }
     }
 
-    // TODO Deprecate
-    private static String getMethodNameFromSignature(String signatureName) {
-        String[] strings = signatureName.split("\\(");
-        String[] subStrings = strings[0].split(" ");
-        return subStrings[subStrings.length - 1];
-    }
-
-    // TODO Deprecate
-    public static String getMethodNameFromFileName(String methodFileName) {
-        String signatureName = getSignatureOfMethodFile(methodFileName);
-        String[] strings = signatureName.split("\\(");
-        String[] subStrings = strings[0].split(" ");
-        return subStrings[subStrings.length - 1];
-    }
-
     private static String extractSignature(String line) {
         return line.replaceFirst(" \\{|\\{", ";");
-    }
-
-    // TODO Deprecate
-    private static String getSignatureOfMethodFile(String fileName) {
-        FileReader fileReader;
-        BufferedReader bufferedReader;
-        String signatureOfMethod;
-        try {
-            fileReader = new FileReader(fileName);
-            bufferedReader = new BufferedReader(fileReader);
-            String line;
-            line = bufferedReader.readLine();
-            signatureOfMethod = extractSignature(line);
-            return signatureOfMethod;
-        } catch (IOException e) {
-            System.err.println("Input fileName [" + fileName + "] failed to run." + e.getMessage());
-            return null;
-        }
     }
 
     public static String getVirtualClassName(String functionName) {

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/LinuxTornadoVM.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/LinuxTornadoVM.java
@@ -33,7 +33,8 @@ public class LinuxTornadoVM implements TornadoVMInterface {
     ProcessBuilder tornadoVMProcessBuilder;
     static Map<String, String> environmentTornadoVM;
     Process tornadoVMProcess;
-    int exitCode;
+    int bytecodeExitCode;
+    int tornadoExitCode;
     String output;
 
     public LinuxTornadoVM() {
@@ -61,14 +62,22 @@ public class LinuxTornadoVM implements TornadoVMInterface {
 
     @Override
     public int getExitCode() {
-        return 0;
+        return bytecodeExitCode | tornadoExitCode;
+    }
+
+    public int getBytecodeExitCode() {
+        return bytecodeExitCode;
+    }
+
+    public int getTornadoExitCode() {
+        return tornadoExitCode;
     }
 
     private String[] getCommandForCompileToBytecode(long id, String functionName) {
         ArrayList<String> args = new ArrayList<>();
         args.add(environmentTornadoVM.get(EnvironmentVariables.JAVA_HOME) + "/bin/javac");
         args.add("-cp");
-        args.add(environmentTornadoVM.get(EnvironmentVariables.TORNADOVM_ROOT) + "/dist/tornado-sdk/tornado-sdk-0.15.2-dev-b19aa7f/share/java/tornado/tornado-api-0.15.2-dev.jar");
+        args.add(environmentTornadoVM.get(EnvironmentVariables.TORNADOVM_ROOT) + "/dist/tornado-sdk/tornado-sdk-0.15.2-dev-f364642/share/java/tornado/tornado-api-0.15.2-dev.jar");
         args.add("-g:vars");
         args.add(environmentTornadoVM.get(EnvironmentVariables.BOILERPLATE_DIR) + "/" + id + "/" + ClassGenerator.getVirtualClassFileName(functionName));
         return args.toArray(new String[args.size()]);
@@ -108,7 +117,7 @@ public class LinuxTornadoVM implements TornadoVMInterface {
 
         tornadoVMProcessBuilder.command(getCommandForCompileToBytecode(id, functionName));
         this.tornadoVMProcess = tornadoVMProcessBuilder.start();
-        int exitCode = tornadoVMProcessWaitFor();
+        bytecodeExitCode = tornadoVMProcessWaitFor();
 
         printOutputOfProcess(tornadoVMProcess);
     }
@@ -134,7 +143,7 @@ public class LinuxTornadoVM implements TornadoVMInterface {
 
         tornadoVMProcessBuilder.command(getCommandForVirtualCompilation(id, deviceDescriptionJsonFileName, kernelName, parameterSizeJsonFileName, generatedKernelFileName));
         this.tornadoVMProcess = tornadoVMProcessBuilder.start();
-        int exitCode = tornadoVMProcessWaitFor();
+        tornadoExitCode = tornadoVMProcessWaitFor();
 
         printOutputOfProcess(tornadoVMProcess);
     }

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/LinuxTornadoVM.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/LinuxTornadoVM.java
@@ -68,7 +68,7 @@ public class LinuxTornadoVM implements TornadoVMInterface {
         ArrayList<String> args = new ArrayList<>();
         args.add(environmentTornadoVM.get(EnvironmentVariables.JAVA_HOME) + "/bin/javac");
         args.add("-cp");
-        args.add(environmentTornadoVM.get(EnvironmentVariables.TORNADOVM_ROOT) + "/dist/tornado-sdk/tornado-sdk-0.15.2-dev-e6fb7fe/share/java/tornado/tornado-api-0.15.2-dev.jar");
+        args.add(environmentTornadoVM.get(EnvironmentVariables.TORNADOVM_ROOT) + "/dist/tornado-sdk/tornado-sdk-0.15.2-dev-b19aa7f/share/java/tornado/tornado-api-0.15.2-dev.jar");
         args.add("-g:vars");
         args.add(environmentTornadoVM.get(EnvironmentVariables.BOILERPLATE_DIR) + "/" + id + "/" + ClassGenerator.getVirtualClassFileName(functionName));
         return args.toArray(new String[args.size()]);

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/LinuxTornadoVM.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/LinuxTornadoVM.java
@@ -106,7 +106,6 @@ public class LinuxTornadoVM implements TornadoVMInterface {
         File file = createNewFileForGeneratedClass(id, classBody);
         writeGeneratedClassToFile(classBody, file, functionName);
 
-        System.out.println("CompilationToBytecode: " + Arrays.toString(getCommandForCompileToBytecode(id, functionName)));
         tornadoVMProcessBuilder.command(getCommandForCompileToBytecode(id, functionName));
         this.tornadoVMProcess = tornadoVMProcessBuilder.start();
         int exitCode = tornadoVMProcessWaitFor();

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/LinuxTornadoVM.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/LinuxTornadoVM.java
@@ -98,11 +98,6 @@ public class LinuxTornadoVM implements TornadoVMInterface {
         return args.toArray(new String[args.size()]);
     }
 
-    // TODO Deprecate
-    private String convertToClassName(String inputClassName) {
-        return inputClassName.replace("class ", "").replace(".", "/");
-    }
-
     public void compileToBytecode(long id, String methodFileName, String functionName) throws IOException, InterruptedException {
         OperatorInfo operatorInfo = OperatorParser.parse(methodFileName, functionName);
         if (operatorInfo == null) {

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/LinuxTornadoVM.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/LinuxTornadoVM.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the ELEGANT Acceleration Service.
+ * URL: https://github.com/elegant-h2020/Elegant-Acceleration-Service.git
+ *
+ * Copyright (c) 2023, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.ac.manchester.elegant.acceleration.service.tools;
 
 import uk.ac.manchester.elegant.acceleration.service.controller.EnvironmentVariables;

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/LinuxTornadoVM.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/LinuxTornadoVM.java
@@ -95,7 +95,7 @@ public class LinuxTornadoVM implements TornadoVMInterface {
     }
 
     public void compileToBytecode(long id, String methodFileName, String functionName) throws IOException, InterruptedException {
-        OperatorInfo operatorInfo = OperatorParser.parse(methodFileName);
+        OperatorInfo operatorInfo = OperatorParser.parse(methodFileName, functionName);
         if (operatorInfo == null) {
             System.err.println("OperatorInfo object is null after parsing the input file.");
         }

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/ObjectField.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/ObjectField.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the ELEGANT Acceleration Service.
+ * URL: https://github.com/elegant-h2020/Elegant-Acceleration-Service.git
+ *
+ * Copyright (c) 2023, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.elegant.acceleration.service.tools;
+
+public class ObjectField implements Cloneable {
+    String fieldName;
+    boolean isDeclaredInRewrittenFunction;
+
+    public ObjectField(String fieldName) {
+        this.fieldName = fieldName;
+        isDeclaredInRewrittenFunction = false;
+    }
+}

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/OperatorInfo.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/OperatorInfo.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the ELEGANT Acceleration Service.
+ * URL: https://github.com/elegant-h2020/Elegant-Acceleration-Service.git
+ *
+ * Copyright (c) 2023, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.elegant.acceleration.service.tools;
+
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class OperatorInfo {
+    ArrayList<String> listOfOperatorObjectNames = new ArrayList<>();
+    ConcurrentHashMap<String, OperatorObject> inputVariableNameToTypeMap = new ConcurrentHashMap<>();
+    ArrayList<String> argumentNameList = new ArrayList<>();
+    ArrayList<OperatorObject> inputList = new ArrayList<>();
+    ConcurrentHashMap<OperatorObject, String> tornadifiedInputList = new ConcurrentHashMap<>();
+    ArrayList<OperatorObject> outputList = new ArrayList<>();
+    ArrayList<OperatorObject> tornadifiedOutputList = new ArrayList<>();
+    boolean isMethodPublic;
+    boolean isMethodStatic;
+    boolean methodUsesMathPackage;
+    String udfName;
+}

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/OperatorInfo.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/OperatorInfo.java
@@ -24,14 +24,19 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class OperatorInfo {
     ArrayList<String> listOfOperatorObjectNames = new ArrayList<>();
+    ConcurrentHashMap<String, OperatorObject> hashMapOfNameAndOperatorObjects = new ConcurrentHashMap<>();
     ConcurrentHashMap<String, OperatorObject> inputVariableNameToTypeMap = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, OperatorObject> inputVariableNameToTornadoTypeMap = new ConcurrentHashMap<>();
     ArrayList<String> argumentNameList = new ArrayList<>();
+    ConcurrentHashMap<String, OperatorObject> variableNameToTypeMap = new ConcurrentHashMap<>();
+    ArrayList<String> variableNameList = new ArrayList<>();
     ArrayList<OperatorObject> inputList = new ArrayList<>();
-    ConcurrentHashMap<OperatorObject, String> tornadifiedInputList = new ConcurrentHashMap<>();
+    ArrayList<OperatorObject> tornadifiedInputList = new ArrayList<>();
     ArrayList<OperatorObject> outputList = new ArrayList<>();
     ArrayList<OperatorObject> tornadifiedOutputList = new ArrayList<>();
     boolean isMethodPublic;
     boolean isMethodStatic;
     boolean methodUsesMathPackage;
     String udfName;
+    String renamedUdfName;
 }

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/OperatorObject.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/OperatorObject.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the ELEGANT Acceleration Service.
+ * URL: https://github.com/elegant-h2020/Elegant-Acceleration-Service.git
+ *
+ * Copyright (c) 2023, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.elegant.acceleration.service.tools;
+
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class OperatorObject {
+    ConcurrentHashMap<String, String> mapTypeToFieldName;
+    ArrayList<String> listOfTypes;
+    boolean isObjectPublic;
+    boolean isObjectStatic;
+    String className;
+
+    public OperatorObject() {
+        mapTypeToFieldName = new ConcurrentHashMap<>();
+        listOfTypes = new ArrayList<>();
+    }
+
+    public OperatorObject(String name) {
+        super();
+        this.className = name;
+    }
+
+    public void addEntryInMapTypeToVariableName(String type, String fieldName) {
+        mapTypeToFieldName.put(fieldName, type);
+    }
+
+    public void addEntryInMapTypeParentObjectName(String type) {
+        listOfTypes.add(type);
+    }
+
+    public String getTypeOfField(String fieldName) {
+        return mapTypeToFieldName.get(fieldName);
+    }
+
+    public ArrayList getListOfTypes() {
+        return listOfTypes;
+    }
+
+}

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/OperatorObject.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/OperatorObject.java
@@ -22,9 +22,10 @@ package uk.ac.manchester.elegant.acceleration.service.tools;
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class OperatorObject {
+public class OperatorObject implements Cloneable {
     ConcurrentHashMap<String, String> mapTypeToFieldName;
     ArrayList<String> listOfTypes;
+    ArrayList<ObjectField> listOfField;
     boolean isObjectPublic;
     boolean isObjectStatic;
     String className;
@@ -32,27 +33,31 @@ public class OperatorObject {
     public OperatorObject() {
         mapTypeToFieldName = new ConcurrentHashMap<>();
         listOfTypes = new ArrayList<>();
+        listOfField = new ArrayList<>();
     }
 
-    public OperatorObject(String name) {
-        super();
-        this.className = name;
-    }
-
-    public void addEntryInMapTypeToVariableName(String type, String fieldName) {
+    public void addEntryInMapTypeToVariableName(String fieldName, String type) {
         mapTypeToFieldName.put(fieldName, type);
     }
 
-    public void addEntryInMapTypeParentObjectName(String type) {
+    public void addEntryInFieldType(String type) {
         listOfTypes.add(type);
     }
 
-    public String getTypeOfField(String fieldName) {
-        return mapTypeToFieldName.get(fieldName);
+    public void addEntryInFieldName(String fieldName) {
+        listOfField.add(new ObjectField(fieldName));
     }
 
     public ArrayList getListOfTypes() {
         return listOfTypes;
     }
 
+    public ArrayList getListOfField() {
+        return listOfField;
+    }
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        return super.clone();
+    }
 }

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/OperatorParser.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/OperatorParser.java
@@ -95,7 +95,7 @@ public class OperatorParser {
             shouldParseObject = false;
             return;
         }
-        if (isLineEmpty(line) || lineStartsAComment(line)) {
+        if (isLineEmpty(line) || lineStartsAComment(line) || line.equals("{")) {
             return;
         }
         StringTokenizer tokenizer = new StringTokenizer(line, " ");
@@ -113,7 +113,11 @@ public class OperatorParser {
                     operatorObject.className = tokenizer.nextToken(" ");
                     operatorInfo.hashMapOfNameAndOperatorObjects.put(operatorObject.className, operatorObject);
                     operatorInfo.listOfOperatorObjectNames.add(operatorObject.className);
-                    tokenizer.nextToken(" "); // this should be the bracket {
+                    break;
+                case "{":
+                    break;
+                case "}":
+                    shouldParseObject = false;
                     break;
                 default:
                     String nextToken = tokenizer.nextToken(" ;");
@@ -146,8 +150,7 @@ public class OperatorParser {
     }
 
     private static void parseOperator(String line, OperatorInfo operatorInfo, String functionName) {
-        if (line.equals("}") || isLineEmpty(line) || lineStartsAComment(line)) {
-            // shouldParseObject = false;
+        if (line.equals("}") || isLineEmpty(line) || lineStartsAComment(line) || line.equals("{")) {
             return;
         }
 

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/OperatorParser.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/OperatorParser.java
@@ -1,0 +1,388 @@
+/*
+ * This file is part of the ELEGANT Acceleration Service.
+ * URL: https://github.com/elegant-h2020/Elegant-Acceleration-Service.git
+ *
+ * Copyright (c) 2023, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.elegant.acceleration.service.tools;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.ListIterator;
+import java.util.StringTokenizer;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+public class OperatorParser {
+
+    private static boolean shouldParseObject = false;
+    private static OperatorObject operatorObject = null;
+
+    private static ConcurrentHashMap<String, OperatorObject> hashMapOfOperatorObjects = new ConcurrentHashMap<>();
+
+    public static void parseMethod(String methodFileName) {
+        System.out.println("The methodFileName is: " + methodFileName);
+        OperatorInfo operatorInfo = new OperatorInfo();
+
+        try (Stream<String> stream = Files.lines(Paths.get(methodFileName), StandardCharsets.UTF_8)) {
+            // Read the content with Stream
+            stream.forEach(s -> {
+                try {
+                    parseLine(s, operatorInfo);
+                } catch (IOException e) {
+                    System.err.println("Runtime error while parsing lines of input files: " + e.getMessage());
+                }
+            });
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static boolean isLineEmpty(String string) {
+        return string.equals("\t") || string.equals(" ");
+    }
+
+    private static boolean lineStartsAComment(String line) {
+        return line.startsWith("//");
+    }
+
+    private static int getNumberOfInputs(String line) {
+        int stringTokenizer = new StringTokenizer(line, ",").countTokens();
+        return stringTokenizer;
+    }
+
+    private static void checkMathFunctionInOperator(String token, OperatorInfo operatorInfo) {
+        if (token.contains("Math.")) {
+            operatorInfo.methodUsesMathPackage = true;
+        }
+    }
+
+    private static void parseLine(String line, OperatorInfo operatorInfo) throws IOException {
+        System.out.println("parseLine Line: " + line);
+        if (isLineEmpty(line) || lineStartsAComment(line)) {
+            return;
+        }
+
+        if (line.contains("class")) {
+            shouldParseObject = true;
+            operatorObject = new OperatorObject();
+        }
+
+        if (shouldParseObject) {
+            System.out.println("parseObjectClass");
+            parseObjectClass(line, operatorObject, operatorInfo);
+        } else {
+            System.out.println("parseOperator");
+            parseOperator(line, operatorInfo);
+        }
+    }
+
+    private static void parseObjectClass(String line, OperatorObject operatorObject, OperatorInfo operatorInfo) {
+        System.out.println("parseObjectClass Line: " + line);
+        if (line.equals("}")) {
+            System.out.println("parseObjectClass: make shouldParseObject false.");
+            shouldParseObject = false;
+            return;
+        }
+        if (isLineEmpty(line) || lineStartsAComment(line)) {
+            return;
+        }
+        StringTokenizer tokenizer = new StringTokenizer(line, " ");
+        while (tokenizer.hasMoreElements()) {
+            String token = tokenizer.nextToken();
+            System.out.println("Token is: " + token);
+
+            switch (token) {
+                case "public":
+                    operatorObject.isObjectPublic = true;
+                    break;
+                case "static":
+                    operatorObject.isObjectStatic = true;
+                    break;
+                case "class":
+                    operatorObject.className = tokenizer.nextToken(" ");
+                    hashMapOfOperatorObjects.put(operatorObject.className, operatorObject);
+                    operatorInfo.listOfOperatorObjectNames.add(operatorObject.className);
+                    tokenizer.nextToken(" "); // this should be the bracket {
+                    break;
+                default:
+                    String nextToken = tokenizer.nextToken(" ;");
+                    System.out.println("token: " + token + " - nextToken: " + nextToken);
+                    operatorObject.addEntryInMapTypeToVariableName(token, nextToken);
+                    operatorObject.addEntryInMapTypeParentObjectName(token);
+                    break;
+            }
+        }
+    }
+
+    private static void parseOperator(String line, OperatorInfo operatorInfo) {
+        System.out.println("parseOperator Line: " + line);
+        if (line.equals("}") || isLineEmpty(line) || lineStartsAComment(line)) {
+            // shouldParseObject = false;
+            return;
+        }
+        StringTokenizer tokenizer = new StringTokenizer(line, " (");
+        while (tokenizer.hasMoreElements()) {
+            String token = tokenizer.nextToken();
+            System.out.println("Token is: " + token);
+
+            switch (token) {
+                case "public":
+                    operatorInfo.isMethodPublic = true;
+                    String nextToken = tokenizer.nextToken();
+
+                    System.out.println("Token2 is: " + nextToken);
+
+                    if (nextToken.equals("static")) {
+                        operatorInfo.isMethodStatic = true;
+                    } else {
+                        if (nextToken.equals("void")) {
+                            break;
+                        } else {
+                            // 1. Check that object name exists in the added parsed list
+                            // 2. Add the operator Object in the outputList
+                            if (operatorInfo.listOfOperatorObjectNames.contains(nextToken)) {
+                                OperatorObject pojo = hashMapOfOperatorObjects.get(nextToken);
+                                operatorInfo.outputList.add(pojo);
+                            } else {
+                                System.err.println("The object (" + nextToken + ") is not recognized.");
+                            }
+                        }
+                    }
+                    break;
+                case "static":
+                    operatorInfo.isMethodStatic = true;
+                    break;
+                case "map":
+                    operatorInfo.udfName = token;
+                    int numberOfInputs = getNumberOfInputs(line);
+                    for (int i = 0; i < numberOfInputs; i++) {
+                        String tokenAfterOperatorName = tokenizer.nextToken();
+                        if (tokenAfterOperatorName.equals("final")) {
+                            tokenAfterOperatorName = tokenizer.nextToken();
+                        }
+                        System.out.println("tokenAfterOperatorName[" + i + "] is: " + tokenAfterOperatorName);
+                        OperatorObject pojo = hashMapOfOperatorObjects.get(tokenAfterOperatorName);
+                        String argumentName = tokenizer.nextToken();
+                        System.out.println("Add in inputList[" + i + "] key: " + argumentName + " - value: " + pojo.className);
+                        operatorInfo.inputList.add(pojo);
+                        operatorInfo.argumentNameList.add(argumentName);
+                        operatorInfo.inputVariableNameToTypeMap.put(argumentName, pojo);
+                    }
+                    break;
+                default:
+                    checkMathFunctionInOperator(token, operatorInfo);
+                    break;
+            }
+        }
+    }
+
+    public static OperatorInfo parse(String methodFileName) {
+        FileReader fileReader;
+        BufferedReader bufferedReader;
+        try {
+            fileReader = new FileReader(methodFileName);
+            bufferedReader = new BufferedReader(fileReader);
+            String line;
+            OperatorInfo operatorInfo = new OperatorInfo();
+            while ((line = bufferedReader.readLine()) != null) {
+                parseLine(line, operatorInfo);
+            }
+            return operatorInfo;
+        } catch (IOException e) {
+            System.out.println("Wrong uploaded file or format. Please ensure that the UDF file is configured properly!");
+        }
+        return null;
+    }
+
+    private static boolean checkHomogeneityOfFields(ArrayList typesOfFields) {
+        AtomicBoolean isHomogeneous = new AtomicBoolean(true);
+        final String[] firstType = { null };
+        typesOfFields.forEach((t) -> {
+            if (firstType[0] == null) {
+                firstType[0] = (String) t;
+                System.out.println("[checkHomogeneityOfFields] first type is: " + t.toString());
+            } else if (!firstType[0].equals(t)) {
+                isHomogeneous.set(false);
+                System.out.println("[checkHomogeneityOfFields] Homogeineity broke fron type: " + t.toString());
+            }
+        });
+
+        return isHomogeneous.get();
+    }
+
+    private static String tornadifyType(ArrayList typesOfFields) {
+        int numOfFields = typesOfFields.size();
+        String typeName = (String) typesOfFields.get(0);
+        switch (typeName) {
+            case "double":
+                if (numOfFields == 1) {
+                    return typeName;
+                } else if (numOfFields == 2) {
+                    return "Double2";
+                } else if (numOfFields == 4) {
+                    return "Double4";
+                } else if (numOfFields == 8) {
+                    return "Double8";
+                } else if (numOfFields == 16) {
+                    return "Double16";
+                }
+                break;
+            case "float":
+                if (numOfFields == 1) {
+                    return typeName;
+                } else if (numOfFields == 2) {
+                    return "Float2";
+                } else if (numOfFields == 4) {
+                    return "Float4";
+                } else if (numOfFields == 8) {
+                    return "Float8";
+                } else if (numOfFields == 16) {
+                    return "Float16";
+                }
+                break;
+            case "long":
+                if (numOfFields == 1) {
+                    return typeName;
+                } else if (numOfFields == 2) {
+                    return "Long2";
+                } else if (numOfFields == 4) {
+                    return "Long4";
+                } else if (numOfFields == 8) {
+                    return "Long8";
+                } else if (numOfFields == 16) {
+                    return "Long16";
+                }
+                break;
+            case "int":
+                if (numOfFields == 1) {
+                    return typeName;
+                } else if (numOfFields == 2) {
+                    return "Int2";
+                } else if (numOfFields == 4) {
+                    return "Int4";
+                } else if (numOfFields == 8) {
+                    return "Int8";
+                } else if (numOfFields == 16) {
+                    return "Int16";
+                }
+                break;
+            default:
+                System.err.println("Not valid type in TornadoVM for operator type [" + typeName + "].");
+                break;
+        }
+        return null;
+    }
+
+    private static String getTornadoVMTypeForPojoNameIfHomogeneous(String pojoName, ArrayList list) {
+        for (int i = 0; i < list.size(); i++) {
+            OperatorObject pojo = (OperatorObject) list.get(i);
+            if (pojo.className.equals(pojoName)) {
+                System.out.println("[tornadifyIO] pojo: " + pojo.className + " - pojoName: " + pojoName + " is used as input");
+                ArrayList typesOfFields = pojo.getListOfTypes();
+                // a. check that types are homogeneous
+                if (checkHomogeneityOfFields(typesOfFields)) {
+                    // b. Find the replacable TornadoVM Type
+                    String tornadoTypeName = tornadifyType(typesOfFields);
+                    System.out.println("[tornadifyIO] getTornadoVMTypeForPojoNameIfHomogeneous pojo: " + pojo.className);
+                    return tornadoTypeName;
+                } else {
+                    System.err.println("The types in operator [" + pojoName + "] should be homogeneous.");
+                }
+            }
+        }
+        return null;
+    }
+
+    static void tornadifyIO(OperatorInfo operatorInfo) {
+        final ListIterator<String> stringListIterator = operatorInfo.listOfOperatorObjectNames.listIterator();
+        // System.out.println("[tornadifyIO] list of objects in operator size: " +
+        // operatorInfo.listOfOperatorObjectNames.size());
+        while (stringListIterator.hasNext()) {
+            String pojoName = stringListIterator.next(); // CartesianCoordinate
+            OperatorObject tornadoInputPojo = null;
+            OperatorObject tornadoOutputPojo = null;
+            // System.out.println("[tornadifyIO] Object name: " + pojoName);
+
+            // Check if operator is used as input
+            // System.out.println("[tornadifyIO] operatorInfo.inputList.size(): " +
+            // operatorInfo.inputList.size());
+            String tornadoInputTypeName = getTornadoVMTypeForPojoNameIfHomogeneous(pojoName, operatorInfo.inputList);
+            if (tornadoInputTypeName != null) {
+                // System.out.println("[tornadifyIO] tornadoInputTypeName is: " +
+                // tornadoInputTypeName);
+                // System.out.println("[tornadifyIO] operatorInfo.inputList.size(): " +
+                // operatorInfo.inputList.size());
+                for (int i = 0; i < operatorInfo.inputList.size(); i++) {
+                    OperatorObject pojo = operatorInfo.inputList.get(i);
+                    // System.out.println("[tornadifyIO] Going to replace input pojo: " +
+                    // pojo.className + " that should be: " + pojoName);
+                    if (pojo.className.equals(pojoName)) {
+                        tornadoInputPojo = pojo;
+                        System.out.println("[tornadifyIO] Input[" + i + "] replace objectType: " + pojo.className + " with " + tornadoInputTypeName);
+                        tornadoInputPojo.className = tornadoInputTypeName;
+                        operatorInfo.inputVariableNameToTypeMap.replace(operatorInfo.argumentNameList.get(i), pojo, tornadoInputPojo);
+                        operatorInfo.tornadifiedInputList.put(tornadoInputPojo, tornadoInputPojo.className);
+                        // operatorInfo.listOfOperatorObjectNames.set((stringListIterator.nextIndex() -
+                        // 1), tornadoInputPojo.className);
+                    }
+                }
+            }
+
+            // Check if operator is used as output
+            String tornadoOutputTypeName = getTornadoVMTypeForPojoNameIfHomogeneous(pojoName, operatorInfo.outputList);
+            if (tornadoOutputTypeName != null) {
+                // System.out.println("[tornadifyIO] tornadoOutputTypeName is: " +
+                // tornadoOutputTypeName);
+                // System.out.println("[tornadifyIO] operatorInfo.outputList.size(): " +
+                // operatorInfo.outputList.size());
+                for (int i = 0; i < operatorInfo.outputList.size(); i++) {
+                    OperatorObject pojo = operatorInfo.outputList.get(i);
+                    // System.out.println("[tornadifyIO] Going to replace output pojo: " +
+                    // pojo.className + " that should be: " + pojoName);
+                    if (pojo.className.equals(pojoName)) {
+                        tornadoOutputPojo = pojo;
+                        System.out.println("[tornadifyIO] Output[" + i + "] replace objectType: " + pojo.className + " with " + tornadoOutputTypeName);
+                        tornadoOutputPojo.className = tornadoOutputTypeName;
+                        operatorInfo.tornadifiedOutputList.add(tornadoOutputPojo);
+                    }
+                }
+            }
+
+            // Replace the object in listOfOperatorObjectNames with the TornadoVM type
+            if (tornadoInputPojo != null && tornadoOutputPojo != null) {
+                assert (tornadoInputPojo.className.equals(tornadoOutputPojo.className));
+                operatorInfo.listOfOperatorObjectNames.set((stringListIterator.nextIndex() - 1), tornadoInputPojo.className);
+            } else if (tornadoInputPojo != null) {
+                operatorInfo.listOfOperatorObjectNames.set((stringListIterator.nextIndex() - 1), tornadoInputPojo.className);
+            } else if (tornadoOutputPojo != null) {
+                operatorInfo.listOfOperatorObjectNames.set((stringListIterator.nextIndex() - 1), tornadoOutputPojo.className);
+            }
+        }
+    }
+
+    static String[] getUniqueOperatorName(OperatorInfo operatorInfo) {
+        String[] distinctOperatorNames = Arrays.stream(operatorInfo.listOfOperatorObjectNames.toArray()).distinct().toArray(String[]::new);
+        return distinctOperatorNames;
+    }
+}

--- a/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/TornadoVMInterface.java
+++ b/src/main/java/uk/ac/manchester/elegant/acceleration/service/tools/TornadoVMInterface.java
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the ELEGANT Acceleration Service.
+ * URL: https://github.com/elegant-h2020/Elegant-Acceleration-Service.git
+ *
+ * Copyright (c) 2023, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.ac.manchester.elegant.acceleration.service.tools;
 
 import java.io.IOException;


### PR DESCRIPTION
This PR provides updates in the tools of the Acceleration Service with respect to:

### 1. Parsing Java UDF (NES map) operators and transforming them to TornadoVM supported types that can be used to generate OpenCL kernels. -> Tornadify UDFs
 - The Acceleration Service supports objects that are homogenized (have fields of the same type (e.g. int, double, float))
 - The Acceleration Service supports any Math function that is [supported by TornadoVM](https://github.com/elegant-h2020/TornadoVM/blob/feat/service/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/math/TornadoMath.java).
For example a map operator from the [NebulaStream examples](https://github.com/nebulastream/nebulastream-tutorial/blob/main/java-client-example/src/main/java/stream/nebula/example/JavaUdfExample.java): 
Method:
```java
static class CartesianCoordinate {
    float x;
    float y;
}

// This is he output type of the UDF.
// The schema of the output stream is derived from the names of the fields
// `angle` and `radius`.
static class PolarCoordinate {
    float angle;
    float radius;
}

public PolarCoordinate map(final CartesianCoordinate inputmap) {
    PolarCoordinate output =  new PolarCoordinate();
    output.radius = Math.sqrt(inputmap.x * inputmap.x + inputmap.y * inputmap.y);
    output.angle = Math.atan2(inputmap.x, inputmap.y);
    return output;
}
```

Generated Kernel: 
```bash
#pragma OPENCL EXTENSION cl_khr_fp64 : enable  
#pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable  
__kernel void map(__global uchar *inputmap, __global uchar *output)
{
  long l_6, l_7; 
  float2 v2f_12, v2f_9; 
  ulong ul_1, ul_0, ul_10, ul_8; 
  int i_5, i_3, i_4, i_2, i_15; 
  float f_14, f_13, f_11; 

  // BLOCK 0
  ul_0  =  (ulong) inputmap;
  ul_1  =  (ulong) output;
  i_2  =  get_global_size(0);
  i_3  =  get_global_id(0);
  // BLOCK 1 MERGES [0 2 ]
  i_4  =  i_3;
  for(;i_4 < 1024;)
  {
    // BLOCK 2
    i_5  =  i_4 << 1;
    l_6  =  (long) i_5;
    l_7  =  l_6 << 2;
    ul_8  =  ul_0 + l_7;
    v2f_9  =  vload2(0, (__global float *) ul_8);
    ul_10  =  ul_1 + l_7;
    f_11  =  atan2(v2f_9.s0, v2f_9.s1);
    f_13  =  f_11;
    f_14  =  f_11;
    v2f_12  =  (float2)(f_13, f_14);
    vstore2(v2f_12, 0, (__global float *) ul_10);
    i_15  =  i_2 + i_4;
    i_4  =  i_15;
  }  // B2
  // BLOCK 3
  return;
}  //  kernel
```

### 2. Parsing Java methods with primitive types and transforming them with the TornadoVM Loop Parallel API to be compiled to OpenCL kernels. -> Tornadify Java methods

Method:
```java
public static void vectorAdd(int[] a, int[] b, int[] c) {
    for ( int i = 0; i < c.length; i++) {
        c[i] = a[i] + b[i];
    }
}
```

Generated Kernel: 
```java
#pragma OPENCL EXTENSION cl_khr_fp64 : enable  
#pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable  
__kernel void vectorAdd(__global uchar *a, __global uchar *b, __global uchar *c)
{
  long l_6, l_7; 
  ulong ul_10, ul_8, ul_12, ul_2, ul_1, ul_0; 
  int i_14, i_13, i_3, i_5, i_4, i_11, i_9; 

  // BLOCK 0
  ul_0  =  (ulong) a;
  ul_1  =  (ulong) b;
  ul_2  =  (ulong) c;
  i_3  =  get_global_size(0);
  i_4  =  get_global_id(0);
  // BLOCK 1 MERGES [0 2 ]
  i_5  =  i_4;
  for(;i_5 < 1024;)
  {
    // BLOCK 2
    l_6  =  (long) i_5;
    l_7  =  l_6 << 2;
    ul_8  =  ul_0 + l_7;
    i_9  =  *((__global int *) ul_8);
    ul_10  =  ul_1 + l_7;
    i_11  =  *((__global int *) ul_10);
    ul_12  =  ul_2 + l_7;
    i_13  =  i_9 + i_11;
    *((__global int *) ul_12)  =  i_13;
    i_14  =  i_3 + i_5;
    i_5  =  i_14;
  }  // B2
  // BLOCK 3
  return;
}  //  kernel
```

### 3. Adding support of error codes that are returned to the requests of the WebService with an appropriate message.